### PR TITLE
isCommandable Modifications

### DIFF
--- a/Orcs Plus/Ch_H_Orcs_ReprimandUpstart.cs
+++ b/Orcs Plus/Ch_H_Orcs_ReprimandUpstart.cs
@@ -63,7 +63,7 @@ namespace Orcs_Plus
             {
                 foreach (UA agent in orcCulture.agents)
                 {
-                    if (agent is UAEN_OrcUpstart upstart2 && (upstart2.inner_profile > upstart2.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart2.inner_menace > upstart2.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
+                    if (agent is UAEN_OrcUpstart upstart2 && !upstart2.isCommandable() && (upstart2.inner_profile > upstart2.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart2.inner_menace > upstart2.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
                     {
                         if (!((upstart2.task is Task_PerformChallenge task && task.challenge is Rt_Orcs_Confinement) || (upstart2.task is CommunityLib.Task_GoToPerformChallengeAtLocation task2 && task2.challenge is Rt_Orcs_Confinement) || upstart2.task is Task_Disrupted || upstart2.task is Task_DisruptUA))
                         {
@@ -136,7 +136,7 @@ namespace Orcs_Plus
             {
                 foreach (UA agent in orcCulture.agents)
                 {
-                    if (agent is UAEN_OrcUpstart upstart && (upstart.inner_profile > upstart.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart.inner_menace > upstart.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
+                    if (agent is UAEN_OrcUpstart upstart && !upstart.isCommandable() && (upstart.inner_profile > upstart.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart.inner_menace > upstart.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
                     {
                         if (!((upstart.task is Task_PerformChallenge task && task.challenge is Rt_Orcs_Confinement) || (upstart.task is CommunityLib.Task_GoToPerformChallengeAtLocation task2 && task2.challenge is Rt_Orcs_Confinement) || upstart.task is Task_Disrupted || upstart.task is Task_DisruptUA))
                         {
@@ -159,9 +159,9 @@ namespace Orcs_Plus
             {
                 foreach (UA agent in orcCulture.agents)
                 {
-                    if (agent is UAEN_OrcUpstart upstart2 && (upstart2.inner_profile > upstart2.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart2.inner_menace > upstart2.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
+                    if (agent is UAEN_OrcUpstart upstart2 && !upstart2.isCommandable() && (upstart2.inner_profile > upstart2.inner_profileMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman) || upstart2.inner_menace > upstart2.inner_menaceMin + (10 * map.param.ch_layLoweReductionPerTurnNonhuman)))
                     {
-                        if (!((upstart2.task is Task_PerformChallenge task && task.challenge is Rt_Orcs_Confinement) || (upstart2.task is CommunityLib.Task_GoToPerformChallengeAtLocation task2 && task2.challenge is Rt_Orcs_Confinement) || upstart2.task is Task_Disrupted || upstart2.task is Task_DisruptUA))
+                        if (!((upstart2.task is Task_PerformChallenge task && task.challenge is Rt_Orcs_Confinement) || (upstart2.task is Task_GoToPerformChallenge task2 && task2.challenge is Rt_Orcs_Confinement) || (upstart2.task is CommunityLib.Task_GoToPerformChallengeAtLocation task3 && task3.challenge is Rt_Orcs_Confinement) || upstart2.task is Task_Disrupted || upstart2.task is Task_DisruptUA))
                         {
                             if (upstart2.inner_profile - upstart2.inner_profileMin + upstart2.inner_menace - upstart2.inner_menaceMin > excessMenaceProfile)
                             {
@@ -175,7 +175,7 @@ namespace Orcs_Plus
 
             if (upstart != null)
             {
-                Rt_Orcs_Confinement confine = upstart.rituals.OfType<Rt_Orcs_Confinement>().FirstOrDefault();
+                Rt_Orcs_Confinement confine = (Rt_Orcs_Confinement)upstart.rituals.FirstOrDefault(rt => rt is Rt_Orcs_Confinement);
 
                 if (confine != null)
                 {
@@ -188,7 +188,8 @@ namespace Orcs_Plus
         {
             return new int[] { 
                 Tags.COOPERATION,
-                Tags.RELIGION
+                Tags.RELIGION,
+                Tags.ORC
             };
         }
 

--- a/Orcs Plus/Rt_Orcs_Confinement.cs
+++ b/Orcs Plus/Rt_Orcs_Confinement.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Code;
+using CommunityLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,6 +32,11 @@ namespace Orcs_Plus
             return "The elders becon and the young come running. The veterans of conflicts passed speak, and the young listen. \"Quite!\", they cry, \"You are too loud. Quite yourself.\". Silence reigns, at least for a time.";
         }
 
+        public override string getRestriction()
+        {
+            return "Cannot self-confine.";
+        }
+
         public override challengeStat getChallengeType()
         {
             return challengeStat.OTHER;
@@ -54,7 +60,23 @@ namespace Orcs_Plus
 
         public override bool validFor(UA ua)
         {
-            return ua is UAEN_OrcUpstart && ua.location.settlement is Set_OrcCamp && ua.location.soc is SG_Orc orcSociety && orcSociety == ua.society;
+            SG_Orc orcSociety = ua.society as SG_Orc;
+            HolyOrder_Orcs orcCulture = ua.society as HolyOrder_Orcs;
+
+            if (orcCulture != null)
+            {
+                orcSociety = orcCulture.orcSociety;
+            }
+
+            if (orcSociety != null && ua.location.soc == orcSociety && ua.location.settlement is Set_OrcCamp)
+            { 
+                if ((ua.task is Task_PerformChallenge challenge && challenge.challenge == this) || (ua.task is Task_GoToPerformChallenge goChallenge && goChallenge.challenge == this) || (ua.task is Task_GoToPerformChallengeAtLocation goLocChallenge && goLocChallenge.challenge == this))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override void turnTick(UA ua)

--- a/Orcs Plus/UAEN_OrcElder.cs
+++ b/Orcs Plus/UAEN_OrcElder.cs
@@ -1,4 +1,5 @@
 ﻿using Assets.Code;
+using FullSerializer;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -166,6 +167,25 @@ namespace Orcs_Plus
 
             base.spendSkillPoint();
             person.skillPoints--;
+        }
+
+        public override bool isCommandable()
+        {
+            bool result = corrupted;
+
+            if (!result)
+            {
+                foreach (Trait trait in person.traits)
+                {
+                    if (trait.grantsCommand())
+                    {
+                        result = true;
+                        break;
+                    }
+                }
+            }
+
+            return result;
         }
 
         public override int[] getPositiveTags()

--- a/Orcs Plus/UAEN_OrcShaman.cs
+++ b/Orcs Plus/UAEN_OrcShaman.cs
@@ -125,6 +125,25 @@ namespace Orcs_Plus
             person.skillPoints--;
         }
 
+        public override bool isCommandable()
+        {
+            bool result = corrupted;
+
+            if (!result)
+            {
+                foreach (Trait trait in person.traits)
+                {
+                    if (trait.grantsCommand())
+                    {
+                        result = true;
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
         public override int[] getPositiveTags()
         {
             int[] tags = new int[2] { Tags.ORC, Tags.UNDEAD };


### PR DESCRIPTION
- Implemented overrides for `isCommandable` in `UAEN_OrcElder` and `UAEN_OrcShaman`.
- Modified "Reprimand Upstart" so tat it cannot target commandable upstarts.
- Modified Confined to Camp so that it can only be performed by an orc agent that has been given the task to perform it externally.